### PR TITLE
Robustify metered tiers whitespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .Rhistory
 .RData
 .Ruserdata
+.DS_Store
+.idea

--- a/R/internal.R
+++ b/R/internal.R
@@ -97,7 +97,8 @@ uploadToS3 <- function(data, bucket, split_files) {
     part <- as.data.frame(lapply(part, function(y) gsub("'", "", y)))
     part <- as.data.frame(lapply(part, function(y) gsub("\\\\", "", y)))
     part <- as.data.frame(lapply(part, function(y) gsub("\\|", "\\\\|", y)))
-    part <- as.data.frame(lapply(part, function(y) gsub("\\n", "", y)))
+    part <- as.data.frame(lapply(part, function(y) gsub("\r\n", "\r", y)))
+    part <- as.data.frame(lapply(part, function(y) gsub("\n", "\r", y)))
     data.table::fwrite(
       part, tmpFile, sep = "|", na = "", col.names = T,
       # ending a line with the delimiter is required, otherwise stl_load_errors


### PR DESCRIPTION
works in my testing
needed for problems with new formatting in metered tiers used in `landed_zapday`
related PR [here](https://github.com/zapier/airflow_env/pull/147)